### PR TITLE
AI-873: When user checks the checkboxes for Copy Partners and Copy User Permissions while creating a copy of the database, then system fails to create the database successfully

### DIFF
--- a/server/src/main/java/org/activityinfo/server/command/handler/CloneDatabaseHandler.java
+++ b/server/src/main/java/org/activityinfo/server/command/handler/CloneDatabaseHandler.java
@@ -315,10 +315,9 @@ public class CloneDatabaseHandler implements CommandHandlerAsync<CloneDatabase, 
 
             switch (sourceRange.iterator().next().getDomain()) {
                 case CuidAdapter.PARTNER_FORM_CLASS_DOMAIN:
-                    if (command.isCopyPartners()) {
-                        for (ResourceId item : sourceRange) {
-                            Partner targetPartner = partnerMapping.get(CuidAdapter.getLegacyIdFromCuid(item));
-                            targetRange.add(CuidAdapter.partnerFormClass(targetPartner.getId()));
+                    for (ResourceId item : sourceRange) { // according to ActivityFormClassBuilder partner range is dbId
+                        if (CuidAdapter.getLegacyIdFromCuid(item) == sourceDb.getId()) {
+                            targetRange.add(CuidAdapter.partnerFormClass(targetDb.getId()));
                         }
                     }
                     break;

--- a/server/src/main/java/org/activityinfo/server/command/handler/CloneDatabaseHandler.java
+++ b/server/src/main/java/org/activityinfo/server/command/handler/CloneDatabaseHandler.java
@@ -315,9 +315,10 @@ public class CloneDatabaseHandler implements CommandHandlerAsync<CloneDatabase, 
 
             switch (sourceRange.iterator().next().getDomain()) {
                 case CuidAdapter.PARTNER_FORM_CLASS_DOMAIN:
-                    for (ResourceId item : sourceRange) { // according to ActivityFormClassBuilder partner range is dbId
-                        if (CuidAdapter.getLegacyIdFromCuid(item) == sourceDb.getId()) {
-                            targetRange.add(CuidAdapter.partnerFormClass(targetDb.getId()));
+                    if (command.isCopyPartners()) {
+                        for (ResourceId item : sourceRange) {
+                            Partner targetPartner = partnerMapping.get(CuidAdapter.getLegacyIdFromCuid(item));
+                            targetRange.add(CuidAdapter.partnerFormClass(targetPartner.getId()));
                         }
                     }
                     break;

--- a/server/src/test/java/org/activityinfo/server/command/CloneDatabaseTest.java
+++ b/server/src/test/java/org/activityinfo/server/command/CloneDatabaseTest.java
@@ -23,8 +23,6 @@ package org.activityinfo.server.command;
 
 import com.extjs.gxt.ui.client.data.BaseModelData;
 import org.activityinfo.fixtures.InjectionSupport;
-import org.activityinfo.i18n.shared.I18N;
-import org.activityinfo.legacy.shared.adapter.ResourceLocatorAdaptor;
 import org.activityinfo.legacy.shared.command.CloneDatabase;
 import org.activityinfo.legacy.shared.command.GetActivityForm;
 import org.activityinfo.legacy.shared.command.GetFormClass;
@@ -36,17 +34,14 @@ import org.activityinfo.model.form.FormClass;
 import org.activityinfo.model.form.FormElement;
 import org.activityinfo.model.form.FormField;
 import org.activityinfo.model.form.FormSection;
-import org.activityinfo.model.legacy.CuidAdapter;
 import org.activityinfo.model.type.ReferenceType;
 import org.activityinfo.model.type.enumerated.EnumType;
 import org.activityinfo.server.database.OnDataSet;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.List;
 
-import static org.activityinfo.core.client.PromiseMatchers.assertResolves;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
@@ -58,27 +53,7 @@ import static org.junit.Assert.assertNotEquals;
 public class CloneDatabaseTest extends CommandTestCase2 {
 
     public static final int PEAR_DATABASE_ID = 1;
-
     public static final int UKRAINE_COUNTRY_ID = 2;
-
-    @Before
-    public final void setup() {
-
-        ActivityFormDTO activity = execute(new GetActivityForm(1));
-        ResourceLocatorAdaptor resourceLocator = new ResourceLocatorAdaptor(getDispatcher());
-
-        FormClass formClass = assertResolves(resourceLocator.getFormClass(activity.getFormClassId()));
-
-        FormField partnerField = new FormField(CuidAdapter.field(activity.getFormClassId(), CuidAdapter.PARTNER_FIELD))
-                .setLabel(I18N.CONSTANTS.partner())
-                .setType(ReferenceType.single(CuidAdapter.partnerFormClass(activity.getDatabaseId())))
-                .setVisible(activity.isEditAllAllowed() && activity.getPartnerRange().size() > 1)
-                .setRequired(true);
-        formClass.addElement(partnerField);
-
-        assertResolves(resourceLocator.persist(formClass));
-    }
-
 
     @Test
     public void fullClone() throws CommandException {


### PR DESCRIPTION
[AI-873](https://bedatadriven.atlassian.net/browse/AI-873): When user checks the checkboxes for Copy Partners and Copy User Permissions while creating a copy of the database, then system fails to create the database successfully

When user checks the checkboxes for Copy Partners and Copy User Permissions while creating a copy of the database, then system fails to create the database successfully.

Check this video for more info: http://www.screencast.com/t/zloRVJgLyD
