### PR TITLE
AI-763: An Handled exception is shown when user leaves Name field empty and clicks on blank space on Profile Settings screen

### DIFF
--- a/server/src/main/java/org/activityinfo/ui/client/page/app/UserProfilePage.java
+++ b/server/src/main/java/org/activityinfo/ui/client/page/app/UserProfilePage.java
@@ -98,7 +98,7 @@ public class UserProfilePage extends FormPanel implements Page {
 
     private void saveProfile() {
         AuthenticatedUser user = new ClientSideAuthProvider().get();
-        if (user != null && user.getUserId() == userProfile.getUserId()) {
+        if (user != null && user.getUserId() == userProfile.getUserId() && isValid()) {
             dispatcher.execute(new UpdateUserProfile(userProfile), new AsyncCallback<VoidResult>() {
                 @Override
                 public void onSuccess(final VoidResult result) {


### PR DESCRIPTION
[AI-763](https://bedatadriven.atlassian.net/browse/AI-763): An Handled exception is shown when user leaves Name field empty and clicks on blank space on Profile Settings screen

An Handled exception is shown when user leaves Name field empty and clicks on blank space on Profile Settings screen

Please refer this video: http://www.screencast.com/t/nIK7FAtWn4oZ