### PR TITLE
AI-849: Newly added location is not available in list of choices for Site Type

### DIFF
--- a/server/src/main/java/org/activityinfo/ui/client/page/config/design/ActivityForm.java
+++ b/server/src/main/java/org/activityinfo/ui/client/page/config/design/ActivityForm.java
@@ -28,17 +28,20 @@ import com.extjs.gxt.ui.client.binding.FormBinding;
 import com.extjs.gxt.ui.client.data.ModelData;
 import com.extjs.gxt.ui.client.event.*;
 import com.extjs.gxt.ui.client.widget.form.*;
+import com.google.common.base.Function;
 import com.google.gwt.user.client.ui.Anchor;
 import org.activityinfo.i18n.shared.I18N;
-import org.activityinfo.legacy.client.Dispatcher;
 import org.activityinfo.legacy.shared.model.ActivityFormDTO;
 import org.activityinfo.legacy.shared.model.LocationTypeDTO;
 import org.activityinfo.legacy.shared.model.Published;
 import org.activityinfo.legacy.shared.model.UserDatabaseDTO;
+import org.activityinfo.promise.Promise;
 import org.activityinfo.ui.client.page.config.design.dialog.NewFormDialog;
 import org.activityinfo.ui.client.widget.legacy.MappingComboBox;
 import org.activityinfo.ui.client.widget.legacy.MappingComboBoxBinding;
 import org.activityinfo.ui.client.widget.legacy.OnlyValidFieldBinding;
+
+import javax.annotation.Nullable;
 
 /**
  * FormClass for editing ActivityDTO
@@ -47,7 +50,7 @@ class ActivityForm extends AbstractDesignForm {
 
     private FormBinding binding;
 
-    public ActivityForm(Dispatcher service, UserDatabaseDTO database) {
+    public ActivityForm(Promise<UserDatabaseDTO> database) {
         super();
 
         binding = new FormBinding(this);
@@ -77,9 +80,17 @@ class ActivityForm extends AbstractDesignForm {
         add(categoryField);
 
         final MappingComboBox<Integer> locationTypeCombo = new MappingComboBox<Integer>();
-        for (LocationTypeDTO type : database.getCountry().getLocationTypes()) {
-            locationTypeCombo.add(type.getId(), type.getName());
-        }
+        database.then(new Function<UserDatabaseDTO, Object>() {
+            @Nullable
+            @Override
+            public Object apply(UserDatabaseDTO userDatabaseDTO) {
+                for (LocationTypeDTO type : userDatabaseDTO.getCountry().getLocationTypes()) {
+                    locationTypeCombo.add(type.getId(), type.getName());
+                }
+                return null;
+            }
+        });
+
         locationTypeCombo.setAllowBlank(false);
         locationTypeCombo.setFieldLabel(I18N.CONSTANTS.locationType());
         this.add(locationTypeCombo);

--- a/server/src/main/java/org/activityinfo/ui/client/page/config/design/DesignView.java
+++ b/server/src/main/java/org/activityinfo/ui/client/page/config/design/DesignView.java
@@ -49,11 +49,14 @@ import com.extjs.gxt.ui.client.widget.treegrid.CellTreeGridSelectionModel;
 import com.extjs.gxt.ui.client.widget.treegrid.EditorTreeGrid;
 import com.extjs.gxt.ui.client.widget.treegrid.TreeGrid;
 import com.extjs.gxt.ui.client.widget.treegrid.TreeGridCellRenderer;
+import com.google.common.base.Function;
 import com.google.gwt.user.client.ui.AbstractImagePrototype;
 import com.google.inject.Inject;
 import org.activityinfo.i18n.shared.I18N;
 import org.activityinfo.legacy.client.Dispatcher;
+import org.activityinfo.legacy.shared.command.GetSchema;
 import org.activityinfo.legacy.shared.model.*;
+import org.activityinfo.promise.Promise;
 import org.activityinfo.ui.client.page.common.dialog.FormDialogCallback;
 import org.activityinfo.ui.client.page.common.dialog.FormDialogImpl;
 import org.activityinfo.ui.client.page.common.dialog.FormDialogTether;
@@ -62,6 +65,7 @@ import org.activityinfo.ui.client.page.common.grid.ImprovedCellTreeGridSelection
 import org.activityinfo.ui.client.page.common.toolbar.UIActions;
 import org.activityinfo.ui.client.style.legacy.icon.IconImageBundle;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -127,6 +131,16 @@ public class DesignView extends AbstractEditorTreeGridView<ModelData, DesignPres
         super.init(presenter, store);
 
         createFormContainer();
+    }
+
+    public Promise<UserDatabaseDTO> getDb() {
+        return service.execute(new GetSchema()).then(new Function<SchemaDTO, UserDatabaseDTO>() {
+            @Nullable
+            @Override
+            public UserDatabaseDTO apply(SchemaDTO schemaDTO) {
+                return schemaDTO.getDatabaseById(db.getId());
+            }
+        });
     }
 
     @Override
@@ -334,7 +348,7 @@ public class DesignView extends AbstractEditorTreeGridView<ModelData, DesignPres
 
     protected AbstractDesignForm createForm(ModelData sel) {
         if (sel instanceof IsActivityDTO) {
-            return new ActivityForm(service, db);
+            return new ActivityForm(getDb());
         } else if (sel instanceof AttributeGroupDTO) {
             return new AttributeGroupForm();
         } else if (sel instanceof AttributeDTO) {

--- a/server/src/main/java/org/activityinfo/ui/client/page/config/design/DesignView.java
+++ b/server/src/main/java/org/activityinfo/ui/client/page/config/design/DesignView.java
@@ -49,14 +49,11 @@ import com.extjs.gxt.ui.client.widget.treegrid.CellTreeGridSelectionModel;
 import com.extjs.gxt.ui.client.widget.treegrid.EditorTreeGrid;
 import com.extjs.gxt.ui.client.widget.treegrid.TreeGrid;
 import com.extjs.gxt.ui.client.widget.treegrid.TreeGridCellRenderer;
-import com.google.common.base.Function;
 import com.google.gwt.user.client.ui.AbstractImagePrototype;
 import com.google.inject.Inject;
 import org.activityinfo.i18n.shared.I18N;
 import org.activityinfo.legacy.client.Dispatcher;
-import org.activityinfo.legacy.shared.command.GetSchema;
 import org.activityinfo.legacy.shared.model.*;
-import org.activityinfo.promise.Promise;
 import org.activityinfo.ui.client.page.common.dialog.FormDialogCallback;
 import org.activityinfo.ui.client.page.common.dialog.FormDialogImpl;
 import org.activityinfo.ui.client.page.common.dialog.FormDialogTether;
@@ -65,7 +62,6 @@ import org.activityinfo.ui.client.page.common.grid.ImprovedCellTreeGridSelection
 import org.activityinfo.ui.client.page.common.toolbar.UIActions;
 import org.activityinfo.ui.client.style.legacy.icon.IconImageBundle;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -131,16 +127,6 @@ public class DesignView extends AbstractEditorTreeGridView<ModelData, DesignPres
         super.init(presenter, store);
 
         createFormContainer();
-    }
-
-    public Promise<UserDatabaseDTO> getDb() {
-        return service.execute(new GetSchema()).then(new Function<SchemaDTO, UserDatabaseDTO>() {
-            @Nullable
-            @Override
-            public UserDatabaseDTO apply(SchemaDTO schemaDTO) {
-                return schemaDTO.getDatabaseById(db.getId());
-            }
-        });
     }
 
     @Override
@@ -348,7 +334,7 @@ public class DesignView extends AbstractEditorTreeGridView<ModelData, DesignPres
 
     protected AbstractDesignForm createForm(ModelData sel) {
         if (sel instanceof IsActivityDTO) {
-            return new ActivityForm(getDb());
+            return new ActivityForm(service, db.getId());
         } else if (sel instanceof AttributeGroupDTO) {
             return new AttributeGroupForm();
         } else if (sel instanceof AttributeDTO) {


### PR DESCRIPTION
[AI-849](https://bedatadriven.atlassian.net/browse/AI-849): Newly added location is not available in list of choices for Site Type

1. Navigate to the design page for a database with design privileges
2. Create a new Location type called "ClosedLocationType" and select "Users may add new locations during data entry"
3. Now create a new Form called "ClosedLocationForm" and choose "Classic" mode.

Current Result: You will note that the 'ClosedLocationType' won't be available in list of choices for Site Type: http://www.screencast.com/t/JNJZeHI6giAz
 
Expected Result: "CLosedLocationType" should appear in the list of choices for "Site Type"